### PR TITLE
Update Ruby version in CI workflow to 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.0-preview1
+          ruby-version: 3.4
           bundler-cache: true
 
       - name: Lint code for consistent style


### PR DESCRIPTION
Might be a good time to turn off preview
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/